### PR TITLE
Support nphysics2d and ncollide2d

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,20 +37,25 @@ simple_logger = "1.2.0"
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
+required-features = ["physics3d"]
 
 [[example]]
 name = "hierarchy"
 path = "examples/hierarchy.rs"
+required-features = ["physics3d"]
 
 [[example]]
 name = "positions"
 path = "examples/positions.rs"
+required-features = ["physics3d"]
 
 [[example]]
 name = "collision"
 path = "examples/collision.rs"
+required-features = ["physics3d"]
 
 [[example]]
 name = "events"
 path = "examples/events.rs"
+required-features = ["physics3d"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,9 @@ specs = "^0.14"
 specs-hierarchy = "^0.3"
 shrev = "^1.0"
 nalgebra = "^0.18"
-ncollide2d = { version = "^0.20", optional = true }
+ncollide2d = { version = "^0.19", optional = true }
 ncollide3d = { version = "^0.19", optional = true }
-nphysics2d = { version = "^0.12", optional = true }
+nphysics2d = { version = "^0.11", optional = true }
 nphysics3d = { version = "^0.11", optional = true }
 amethyst_core = { version = "^0.7", optional = true }
 objekt = "0.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,21 @@ description = "nphysics integration for the Specs entity component system"
 keywords = ["specs", "nphysics", "nphysics3d"]
 
 [features]
-default = []
-
+physics3d = ["ncollide3d", "nphysics3d"]
+physics2d = ["ncollide2d", "nphysics2d"]
 amethyst = ["amethyst_core"]
 
 [dependencies]
-log = "0.4.6"
-specs = "0.14.3"
-specs-hierarchy = "0.3.1"
-shrev = "1.1.1"
-nalgebra = "0.18.0"
-ncollide3d = "0.19"
-nphysics3d = "0.11.1"
-amethyst_core = { version = "0.7.0", optional = true }
+log = "^0.4.6"
+specs = "^0.14"
+specs-hierarchy = "^0.3"
+shrev = "^1.0"
+nalgebra = "^0.18"
+ncollide2d = { version = "^0.20", optional = true }
+ncollide3d = { version = "^0.19", optional = true }
+nphysics2d = { version = "^0.12", optional = true }
+nphysics3d = { version = "^0.11", optional = true }
+amethyst_core = { version = "^0.7", optional = true }
 objekt = "0.1.2"
 
 [dev-dependencies]

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -1,24 +1,19 @@
 use specs::{Component, DenseVecStorage, FlaggedStorage};
-
-use crate::{
-    nalgebra::RealField,
-    nphysics::{
-        algebra::ForceType,
-        object::{Body, BodyHandle, BodyPart, BodyStatus, RigidBody, RigidBodyDesc},
-    },
-};
+use nalgebra::RealField;
 
 #[cfg(feature = "physics3d")]
-use crate::nalgebra::{Point3 as Point, Matrix3, Isometry3 as Isometry};
+use nalgebra::{Point3 as Point, Matrix3, Isometry3 as Isometry};
 
 #[cfg(feature = "physics2d")]
-use crate::nalgebra::{Point2 as Point, Isometry2 as Isometry};
+use nalgebra::{Point2 as Point, Isometry2 as Isometry};
 
 #[cfg(feature = "physics3d")]
-use crate::nphysics::algebra::{Force3 as Force, Velocity3 as Velocity};
+use nphysics::{algebra::{Force3 as Force, Velocity3 as Velocity, ForceType,},
+                 object::{Body, BodyHandle, BodyPart, BodyStatus, RigidBody, RigidBodyDesc}};
 
 #[cfg(feature = "physics2d")]
-use crate::nphysics::algebra::{Force2 as Force, Velocity2 as Velocity};
+use nphysics::{algebra::{Force2 as Force, Velocity2 as Velocity, ForceType,},
+                 object::{Body, BodyHandle, BodyPart, BodyStatus, RigidBody, RigidBodyDesc}};
 
 
 pub mod util {

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -20,6 +20,7 @@ pub mod util {
     use specs::{Component, DenseVecStorage, FlaggedStorage};
 
     use super::{Position, Isometry, RealField};
+    use objekt::private::ops::{Deref, DerefMut};
 
     pub struct SimplePosition<N: RealField>(pub Isometry<N>);
 
@@ -35,6 +36,20 @@ pub mod util {
 
     impl<N: RealField> Component for SimplePosition<N> {
         type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
+    }
+
+    impl<N: RealField> Deref for SimplePosition<N> {
+        type Target = Isometry<N>;
+
+        fn deref(&self) -> &Self::Target {
+            &self.0
+        }
+    }
+
+    impl<N: RealField> DerefMut for SimplePosition<N> {
+        fn deref_mut(&mut self) -> &mut Self::Target {
+            &mut self.0
+        }
     }
 }
 

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -36,12 +36,6 @@ pub mod util {
         fn isometry_mut(&mut self) -> &mut Isometry<N> {
             &mut self.0
         }
-
-        fn set_isometry(&mut self, isometry: &Isometry<N>) -> &mut Self {
-            self.0.rotation = isometry.rotation;
-            self.0.translation = isometry.translation;
-            self
-        }
     }
 
     impl<N: RealField> Component for SimplePosition<N> {
@@ -60,7 +54,6 @@ pub trait Position<N: RealField>:
 {
     fn isometry(&self) -> &Isometry<N>;
     fn isometry_mut(&mut self) -> &mut Isometry<N>;
-    fn set_isometry(&mut self, isometry: &Isometry<N>) -> &mut Self;
 }
 
 #[cfg(feature = "amethyst")]
@@ -71,10 +64,6 @@ impl Position<f32> for amethyst_core::Transform {
 
     fn isometry_mut(&mut self) -> &mut Isometry<f32> {
         self.isometry_mut()
-    }
-
-    fn set_isometry(&mut self, isometry: &Isometry<f32>) -> &mut Self {
-        self.set_isometry(*isometry)
     }
 }
 

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -2,10 +2,10 @@ use specs::{Component, DenseVecStorage, FlaggedStorage};
 use nalgebra::RealField;
 
 #[cfg(feature = "physics3d")]
-use nalgebra::{Point3 as Point, Matrix3, Isometry3 as Isometry};
+use nalgebra::{Point3 as Point, Matrix3};
 
 #[cfg(feature = "physics2d")]
-use nalgebra::{Point2 as Point, Isometry2 as Isometry};
+use nalgebra::{Point2 as Point};
 
 #[cfg(feature = "physics3d")]
 use nphysics::{algebra::{Force3 as Force, Velocity3 as Velocity, ForceType,},
@@ -14,84 +14,6 @@ use nphysics::{algebra::{Force3 as Force, Velocity3 as Velocity, ForceType,},
 #[cfg(feature = "physics2d")]
 use nphysics::{algebra::{Force2 as Force, Velocity2 as Velocity, ForceType,},
                  object::{Body, BodyHandle, BodyPart, BodyStatus, RigidBody, RigidBodyDesc}};
-
-
-pub mod util {
-    use specs::{Component, DenseVecStorage, FlaggedStorage};
-
-    use super::{Position, Isometry, RealField};
-    use objekt::private::ops::{Deref, DerefMut};
-
-    pub struct SimplePosition<N: RealField>(pub Isometry<N>);
-
-    impl<N: RealField> Position<N> for SimplePosition<N> {
-        fn isometry(&self) -> &Isometry<N> {
-            &self.0
-        }
-
-        fn isometry_mut(&mut self) -> &mut Isometry<N> {
-            &mut self.0
-        }
-    }
-
-    impl<N: RealField> Component for SimplePosition<N> {
-        type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
-    }
-
-    impl<N: RealField> Deref for SimplePosition<N> {
-        type Target = Isometry<N>;
-
-        fn deref(&self) -> &Self::Target {
-            &self.0
-        }
-    }
-
-    impl<N: RealField> DerefMut for SimplePosition<N> {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.0
-        }
-    }
-}
-
-/// An implementation of the `Position` trait is required for the
-/// synchronisation of the position of Specs and nphysics objects.
-///
-/// Initially, it is used to position bodies in the nphysics `World`. Then after
-/// progressing the `World` it is used to synchronise the updated positions back
-/// towards Specs.
-pub trait Position<N: RealField>:
-    Component<Storage = FlaggedStorage<Self, DenseVecStorage<Self>>> + Send + Sync
-{
-    fn isometry(&self) -> &Isometry<N>;
-    fn isometry_mut(&mut self) -> &mut Isometry<N>;
-
-    /// Helper function to extract the location of this `Position`. Using `Position::isometry()` is
-    /// preferable, but can be harder to work with. The translation of this `Position` can be set
-    /// using `Position::isometry_mut()`.
-    fn translation(&self) -> Point<N> {
-        self.isometry().translation.vector.into()
-    }
-
-    /// Helper function to extract the rotation of this `Position`. Using `Position::isometry()` is
-    /// preferable, but can be harder to work with. The rotation of this `Position` can be set
-    /// using `Position::isometry_mut()`. This is only available when the `physics2d` feature is
-    /// enabled.
-    #[cfg(feature = "physics2d")]
-    fn angle(&self) -> N {
-        self.isometry().rotation.angle()
-    }
-}
-
-#[cfg(feature = "amethyst")]
-impl Position<f32> for amethyst_core::Transform {
-    fn isometry(&self) -> &Isometry<f32> {
-        self.isometry()
-    }
-
-    fn isometry_mut(&mut self) -> &mut Isometry<f32> {
-        self.isometry_mut()
-    }
-}
 
 /// The `PhysicsBody` `Component` represents a `PhysicsWorld` `RigidBody` in
 /// Specs and contains all the data required for the synchronisation between

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -143,19 +143,19 @@ impl<N: RealField> PhysicsBody<N> {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// use specs_physics::{
-///     nalgebra::{Matrix3, Point},
-///     nphysics::{algebra::Velocity, object::BodyStatus},
+///     nalgebra::{Matrix3, Point3},
+///     nphysics::{algebra::Velocity3, object::BodyStatus},
 ///     PhysicsBodyBuilder,
 /// };
 ///
 /// let physics_body = PhysicsBodyBuilder::from(BodyStatus::Dynamic)
 ///     .gravity_enabled(true)
-///     .velocity(Velocity::linear(1.0, 1.0, 1.0))
+///     .velocity(Velocity3::linear(1.0, 1.0, 1.0))
 ///     .angular_inertia(Matrix3::from_diagonal_element(3.0))
 ///     .mass(1.3)
-///     .local_center_of_mass(Point::new(0.0, 0.0, 0.0))
+///     .local_center_of_mass(Point3::new(0.0, 0.0, 0.0))
 ///     .build();
 /// ```
 pub struct PhysicsBodyBuilder<N: RealField> {

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -1,33 +1,43 @@
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
 use crate::{
-    nalgebra::{Isometry3, Matrix3, Point3, RealField},
+    nalgebra::RealField,
     nphysics::{
-        algebra::{Force3, ForceType, Velocity3},
+        algebra::ForceType,
         object::{Body, BodyHandle, BodyPart, BodyStatus, RigidBody, RigidBodyDesc},
     },
 };
 
+#[cfg(feature = "physics3d")]
+use crate::nalgebra::{Point3 as Point, Matrix3, Isometry3 as Isometry};
+
+#[cfg(feature = "physics2d")]
+use crate::nalgebra::{Point2 as Point, Isometry2 as Isometry};
+
+#[cfg(feature = "physics3d")]
+use crate::nphysics::algebra::{Force3 as Force, Velocity3 as Velocity};
+
+#[cfg(feature = "physics2d")]
+use crate::nphysics::algebra::{Force2 as Force, Velocity2 as Velocity};
+
+
 pub mod util {
     use specs::{Component, DenseVecStorage, FlaggedStorage};
 
-    use crate::{
-        bodies::Position,
-        nalgebra::{Isometry3, RealField},
-    };
+    use super::{Position, Isometry, RealField};
 
-    pub struct SimplePosition<N: RealField>(pub Isometry3<N>);
+    pub struct SimplePosition<N: RealField>(pub Isometry<N>);
 
     impl<N: RealField> Position<N> for SimplePosition<N> {
-        fn isometry(&self) -> &Isometry3<N> {
+        fn isometry(&self) -> &Isometry<N> {
             &self.0
         }
 
-        fn isometry_mut(&mut self) -> &mut Isometry3<N> {
+        fn isometry_mut(&mut self) -> &mut Isometry<N> {
             &mut self.0
         }
 
-        fn set_isometry(&mut self, isometry: &Isometry3<N>) -> &mut Self {
+        fn set_isometry(&mut self, isometry: &Isometry<N>) -> &mut Self {
             self.0.rotation = isometry.rotation;
             self.0.translation = isometry.translation;
             self
@@ -48,22 +58,22 @@ pub mod util {
 pub trait Position<N: RealField>:
     Component<Storage = FlaggedStorage<Self, DenseVecStorage<Self>>> + Send + Sync
 {
-    fn isometry(&self) -> &Isometry3<N>;
-    fn isometry_mut(&mut self) -> &mut Isometry3<N>;
-    fn set_isometry(&mut self, isometry: &Isometry3<N>) -> &mut Self;
+    fn isometry(&self) -> &Isometry<N>;
+    fn isometry_mut(&mut self) -> &mut Isometry<N>;
+    fn set_isometry(&mut self, isometry: &Isometry<N>) -> &mut Self;
 }
 
 #[cfg(feature = "amethyst")]
 impl Position<f32> for amethyst_core::Transform {
-    fn isometry(&self) -> &Isometry3<f32> {
+    fn isometry(&self) -> &Isometry<f32> {
         self.isometry()
     }
 
-    fn isometry_mut(&mut self) -> &mut Isometry3<f32> {
+    fn isometry_mut(&mut self) -> &mut Isometry<f32> {
         self.isometry_mut()
     }
 
-    fn set_isometry(&mut self, isometry: &Isometry3<f32>) -> &mut Self {
+    fn set_isometry(&mut self, isometry: &Isometry<f32>) -> &mut Self {
         self.set_isometry(*isometry)
     }
 }
@@ -76,11 +86,14 @@ pub struct PhysicsBody<N: RealField> {
     pub(crate) handle: Option<BodyHandle>,
     pub gravity_enabled: bool,
     pub body_status: BodyStatus,
-    pub velocity: Velocity3<N>,
+    pub velocity: Velocity<N>,
+    #[cfg(feature = "physics3d")]
     pub angular_inertia: Matrix3<N>,
+    #[cfg(feature = "physics2d")]
+    pub angular_inertia: N,
     pub mass: N,
-    pub local_center_of_mass: Point3<N>,
-    external_forces: Force3<N>,
+    pub local_center_of_mass: Point<N>,
+    external_forces: Force<N>,
 }
 
 impl<N: RealField> Component for PhysicsBody<N> {
@@ -88,11 +101,11 @@ impl<N: RealField> Component for PhysicsBody<N> {
 }
 
 impl<N: RealField> PhysicsBody<N> {
-    pub fn check_external_force(&self) -> &Force3<N> {
+    pub fn check_external_force(&self) -> &Force<N> {
         &self.external_forces
     }
 
-    pub fn apply_external_force(&mut self, force: &Force3<N>) -> &mut Self {
+    pub fn apply_external_force(&mut self, force: &Force<N>) -> &mut Self {
         self.external_forces += *force;
         self
     }
@@ -133,9 +146,9 @@ impl<N: RealField> PhysicsBody<N> {
         self
     }
 
-    fn drain_external_force(&mut self) -> Force3<N> {
+    fn drain_external_force(&mut self) -> Force<N> {
         let value = self.external_forces;
-        self.external_forces = Force3::<N>::zero();
+        self.external_forces = Force::<N>::zero();
         value
     }
 }
@@ -148,26 +161,29 @@ impl<N: RealField> PhysicsBody<N> {
 ///
 /// ```rust
 /// use specs_physics::{
-///     nalgebra::{Matrix3, Point3},
-///     nphysics::{algebra::Velocity3, object::BodyStatus},
+///     nalgebra::{Matrix3, Point},
+///     nphysics::{algebra::Velocity, object::BodyStatus},
 ///     PhysicsBodyBuilder,
 /// };
 ///
 /// let physics_body = PhysicsBodyBuilder::from(BodyStatus::Dynamic)
 ///     .gravity_enabled(true)
-///     .velocity(Velocity3::linear(1.0, 1.0, 1.0))
+///     .velocity(Velocity::linear(1.0, 1.0, 1.0))
 ///     .angular_inertia(Matrix3::from_diagonal_element(3.0))
 ///     .mass(1.3)
-///     .local_center_of_mass(Point3::new(0.0, 0.0, 0.0))
+///     .local_center_of_mass(Point::new(0.0, 0.0, 0.0))
 ///     .build();
 /// ```
 pub struct PhysicsBodyBuilder<N: RealField> {
     gravity_enabled: bool,
     body_status: BodyStatus,
-    velocity: Velocity3<N>,
+    velocity: Velocity<N>,
+    #[cfg(feature = "physics3d")]
     angular_inertia: Matrix3<N>,
+    #[cfg(feature = "physics2d")]
+    angular_inertia: N,
     mass: N,
-    local_center_of_mass: Point3<N>,
+    local_center_of_mass: Point<N>,
 }
 
 impl<N: RealField> From<BodyStatus> for PhysicsBodyBuilder<N> {
@@ -177,10 +193,13 @@ impl<N: RealField> From<BodyStatus> for PhysicsBodyBuilder<N> {
         Self {
             gravity_enabled: false,
             body_status,
-            velocity: Velocity3::zero(),
+            velocity: Velocity::zero(),
+            #[cfg(feature = "physics3d")]
             angular_inertia: Matrix3::zeros(),
+            #[cfg(feature = "physics2d")]
+            angular_inertia: N::zero(),
             mass: N::from_f32(1.2).unwrap(),
-            local_center_of_mass: Point3::origin(),
+            local_center_of_mass: Point::origin(),
         }
     }
 }
@@ -193,13 +212,21 @@ impl<N: RealField> PhysicsBodyBuilder<N> {
     }
 
     // Sets the `velocity` value of the `PhysicsBodyBuilder`.
-    pub fn velocity(mut self, velocity: Velocity3<N>) -> Self {
+    pub fn velocity(mut self, velocity: Velocity<N>) -> Self {
         self.velocity = velocity;
         self
     }
 
     /// Sets the `angular_inertia` value of the `PhysicsBodyBuilder`.
+    #[cfg(feature = "physics3d")]
     pub fn angular_inertia(mut self, angular_inertia: Matrix3<N>) -> Self {
+        self.angular_inertia = angular_inertia;
+        self
+    }
+
+    /// Sets the `angular_inertia` value of the `PhysicsBodyBuilder`.
+    #[cfg(feature = "physics2d")]
+    pub fn angular_inertia(mut self, angular_inertia: N) -> Self {
         self.angular_inertia = angular_inertia;
         self
     }
@@ -211,7 +238,7 @@ impl<N: RealField> PhysicsBodyBuilder<N> {
     }
 
     /// Sets the `local_center_of_mass` value of the `PhysicsBodyBuilder`.
-    pub fn local_center_of_mass(mut self, local_center_of_mass: Point3<N>) -> Self {
+    pub fn local_center_of_mass(mut self, local_center_of_mass: Point<N>) -> Self {
         self.local_center_of_mass = local_center_of_mass;
         self
     }
@@ -227,7 +254,7 @@ impl<N: RealField> PhysicsBodyBuilder<N> {
             angular_inertia: self.angular_inertia,
             mass: self.mass,
             local_center_of_mass: self.local_center_of_mass,
-            external_forces: Force3::zero(),
+            external_forces: Force::zero(),
         }
     }
 }

--- a/src/bodies.rs
+++ b/src/bodies.rs
@@ -49,6 +49,22 @@ pub trait Position<N: RealField>:
 {
     fn isometry(&self) -> &Isometry<N>;
     fn isometry_mut(&mut self) -> &mut Isometry<N>;
+
+    /// Helper function to extract the location of this `Position`. Using `Position::isometry()` is
+    /// preferable, but can be harder to work with. The translation of this `Position` can be set
+    /// using `Position::isometry_mut()`.
+    fn translation(&self) -> Point<N> {
+        self.isometry().translation.vector.into()
+    }
+
+    /// Helper function to extract the rotation of this `Position`. Using `Position::isometry()` is
+    /// preferable, but can be harder to work with. The rotation of this `Position` can be set
+    /// using `Position::isometry_mut()`. This is only available when the `physics2d` feature is
+    /// enabled.
+    #[cfg(feature = "physics2d")]
+    fn angle(&self) -> N {
+        self.isometry().rotation.angle()
+    }
 }
 
 #[cfg(feature = "amethyst")]

--- a/src/colliders.rs
+++ b/src/colliders.rs
@@ -202,7 +202,7 @@ impl<N: RealField> PhysicsCollider<N> {
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// use specs_physics::{
 ///     colliders::Shape,
 ///     nalgebra::{Isometry, Vector3},

--- a/src/colliders.rs
+++ b/src/colliders.rs
@@ -3,11 +3,11 @@ use std::{f32::consts::PI, fmt, ops::Deref};
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
 use crate::{
-    nalgebra::{DMatrix, Isometry3, Point2, Point3, RealField, Unit, Vector3},
+    nalgebra::{Point2, Point3, RealField, Unit},
     ncollide::{
         shape::{
-            Ball, Capsule, Compound, ConvexHull, Cuboid, HeightField, Plane, Polyline, Segment,
-            ShapeHandle, TriMesh, Triangle,
+            Ball, Capsule, Compound, Cuboid, HeightField, Plane, Polyline, Segment,
+            ShapeHandle,
         },
         world::CollisionGroups,
     },
@@ -16,6 +16,16 @@ use crate::{
         object::ColliderHandle,
     },
 };
+
+
+#[cfg(feature = "physics3d")]
+use crate::ncollide::shape::{ConvexHull, TriMesh, Triangle};
+
+#[cfg(feature = "physics3d")]
+use nalgebra::{Isometry3 as Isometry, DMatrix, Vector3 as Vector, Point3 as Point};
+
+#[cfg(feature = "physics2d")]
+use nalgebra::{Isometry2 as Isometry, Vector2 as Vector, DVector, Point2 as Point};
 
 pub type MeshData<N> = (Vec<Point3<N>>, Vec<Point3<usize>>, Option<Vec<Point2<N>>>);
 
@@ -52,36 +62,41 @@ pub enum Shape<N: RealField> {
         radius: N,
     },
     Compound {
-        parts: Vec<(Isometry3<N>, Shape<N>)>,
+        parts: Vec<(Isometry<N>, Shape<N>)>,
     },
+    #[cfg(feature = "physics3d")]
     ConvexHull {
-        points: Vec<Point3<N>>,
+        points: Vec<Point<N>>,
     },
     Cuboid {
-        half_extents: Vector3<N>,
+        half_extents: Vector<N>,
     },
     HeightField {
+        #[cfg(feature = "physics3d")]
         heights: DMatrix<N>,
-        scale: Vector3<N>,
+        #[cfg(feature = "physics2d")]
+        heights: DVector<N>,
+        scale: Vector<N>,
     },
     Plane {
-        normal: Unit<Vector3<N>>,
+        normal: Unit<Vector<N>>,
     },
     Polyline {
-        points: Vec<Point3<N>>,
+        points: Vec<Point<N>>,
         indices: Option<Vec<Point2<usize>>>,
     },
     Segment {
-        a: Point3<N>,
-        b: Point3<N>,
+        a: Point<N>,
+        b: Point<N>,
     },
+    #[cfg(feature = "physics3d")]
     TriMesh {
         handle: Box<dyn IntoMesh<N = N>>,
     },
     Triangle {
-        a: Point3<N>,
-        b: Point3<N>,
-        c: Point3<N>,
+        a: Point<N>,
+        b: Point<N>,
+        c: Point<N>,
     },
 }
 
@@ -102,6 +117,7 @@ impl<N: RealField> Shape<N> {
                     .map(|part| (part.0, part.1.handle()))
                     .collect(),
             )),
+            #[cfg(feature = "physics3d")]
             Shape::ConvexHull { points } => ShapeHandle::new(
                 ConvexHull::try_from_points(&points)
                     .expect("Failed to generate Convex Hull from points."),
@@ -115,11 +131,15 @@ impl<N: RealField> Shape<N> {
                 ShapeHandle::new(Polyline::new(points.clone(), indices.clone()))
             }
             Shape::Segment { a, b } => ShapeHandle::new(Segment::new(*a, *b)),
+            #[cfg(feature = "physics3d")]
             Shape::TriMesh { handle } => {
                 let data = handle.points();
                 ShapeHandle::new(TriMesh::new(data.0, data.1, data.2))
             }
+            #[cfg(feature = "physics3d")]
             Shape::Triangle { a, b, c } => ShapeHandle::new(Triangle::new(*a, *b, *c)),
+            #[cfg(feature = "physics2d")]
+            Shape::Triangle { a, b, c } => ShapeHandle::new(Polyline::new(vec![*a, *b, *c], None)),
         }
     }
 }
@@ -132,7 +152,7 @@ impl<N: RealField> Shape<N> {
 pub struct PhysicsCollider<N: RealField> {
     pub(crate) handle: Option<ColliderHandle>,
     pub shape: Shape<N>,
-    pub offset_from_parent: Isometry3<N>,
+    pub offset_from_parent: Isometry<N>,
     pub density: N,
     pub material: MaterialHandle<N>,
     pub margin: N,
@@ -190,14 +210,14 @@ impl<N: RealField> PhysicsCollider<N> {
 /// ```rust
 /// use specs_physics::{
 ///     colliders::Shape,
-///     nalgebra::{Isometry3, Vector3},
+///     nalgebra::{Isometry, Vector3},
 ///     ncollide::world::CollisionGroups,
 ///     nphysics::material::{BasicMaterial, MaterialHandle},
 ///     PhysicsColliderBuilder,
 /// };
 ///
 /// let physics_collider = PhysicsColliderBuilder::from(Shape::Cuboid{ half_extents: Vector3::new(10.0, 10.0, 1.0) })
-///     .offset_from_parent(Isometry3::identity())
+///     .offset_from_parent(Isometry::identity())
 ///     .density(1.2)
 ///     .material(MaterialHandle::new(BasicMaterial::default()))
 ///     .margin(0.02)
@@ -209,7 +229,7 @@ impl<N: RealField> PhysicsCollider<N> {
 /// ```
 pub struct PhysicsColliderBuilder<N: RealField> {
     shape: Shape<N>,
-    offset_from_parent: Isometry3<N>,
+    offset_from_parent: Isometry<N>,
     density: N,
     material: MaterialHandle<N>,
     margin: N,
@@ -225,7 +245,7 @@ impl<N: RealField> From<Shape<N>> for PhysicsColliderBuilder<N> {
     fn from(shape: Shape<N>) -> Self {
         Self {
             shape,
-            offset_from_parent: Isometry3::identity(),
+            offset_from_parent: Isometry::identity(),
             density: N::from_f32(1.3).unwrap(),
             material: MaterialHandle::new(BasicMaterial::default()),
             margin: N::from_f32(0.2).unwrap(), // default was: 0.01
@@ -239,7 +259,7 @@ impl<N: RealField> From<Shape<N>> for PhysicsColliderBuilder<N> {
 
 impl<N: RealField> PhysicsColliderBuilder<N> {
     /// Sets the `offset_from_parent` value of the `PhysicsColliderBuilder`.
-    pub fn offset_from_parent(mut self, offset_from_parent: Isometry3<N>) -> Self {
+    pub fn offset_from_parent(mut self, offset_from_parent: Isometry<N>) -> Self {
         self.offset_from_parent = offset_from_parent;
         self
     }

--- a/src/colliders.rs
+++ b/src/colliders.rs
@@ -2,24 +2,19 @@ use std::{f32::consts::PI, fmt, ops::Deref};
 
 use specs::{Component, DenseVecStorage, FlaggedStorage};
 
-use crate::{
-    nalgebra::{Point2, Point3, RealField, Unit},
-    ncollide::{
-        shape::{
-            Ball, Capsule, Compound, Cuboid, HeightField, Plane, Polyline, Segment,
-            ShapeHandle,
-        },
-        world::CollisionGroups,
-    },
-    nphysics::{
-        material::{BasicMaterial, MaterialHandle},
-        object::ColliderHandle,
-    },
+use nalgebra::{Point2, Point3, RealField, Unit};
+use ncollide::{
+    shape::{Ball, Capsule, Compound, Cuboid, HeightField, Plane, Polyline, Segment, ShapeHandle},
+    world::CollisionGroups
+};
+use nphysics::{
+    material::{BasicMaterial, MaterialHandle},
+    object::ColliderHandle,
 };
 
 
 #[cfg(feature = "physics3d")]
-use crate::ncollide::shape::{ConvexHull, TriMesh, Triangle};
+use ncollide::shape::{ConvexHull, TriMesh, Triangle};
 
 #[cfg(feature = "physics3d")]
 use nalgebra::{Isometry3 as Isometry, DMatrix, Vector3 as Vector, Point3 as Point};

--- a/src/events.rs
+++ b/src/events.rs
@@ -1,6 +1,7 @@
 use specs::Entity;
 
-use crate::{ncollide::query::Proximity, shrev::EventChannel};
+use ncollide::query::Proximity;
+use shrev::EventChannel;
 
 /// The `ContactType` is set accordingly to whether a contact began or ended.
 #[derive(Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,11 +59,6 @@
 //!     fn isometry_mut(&mut self) -> &mut Isometry3<f32> {
 //!         &mut self.0
 //!     }
-//!
-//!     fn set_isometry(&mut self, isometry: &Isometry3<f32>) -> &mut Pos {
-//!         self.0 = *isometry;
-//!         self
-//!     }
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,20 +253,21 @@ use specs::{
 use specs_hierarchy::Parent;
 
 pub use self::{
-    bodies::{util::SimplePosition, PhysicsBody, PhysicsBodyBuilder},
+    bodies::{PhysicsBody, PhysicsBodyBuilder},
+    positon::{Position, SimplePosition},
     colliders::{PhysicsCollider, PhysicsColliderBuilder},
 };
 
+use nphysics::{
+    counters::Counters,
+    material::MaterialsCoefficientsTable,
+    object::{BodyHandle, ColliderHandle},
+    solver::IntegrationParameters,
+    world::World,
+};
+
 use self::{
-    bodies::Position,
     nalgebra::RealField,
-    nphysics::{
-        counters::Counters,
-        material::MaterialsCoefficientsTable,
-        object::{BodyHandle, ColliderHandle},
-        solver::IntegrationParameters,
-        world::World,
-    },
     systems::{
         PhysicsStepperSystem, SyncBodiesFromPhysicsSystem, SyncBodiesToPhysicsSystem,
         SyncCollidersToPhysicsSystem, SyncParametersToPhysicsSystem,
@@ -284,6 +285,7 @@ pub mod colliders;
 pub mod events;
 pub mod parameters;
 pub mod systems;
+pub mod positon;
 
 /// Resource holding the internal fields where physics computation occurs.
 /// Some inspection methods are exposed to allow debugging.
@@ -377,7 +379,7 @@ impl Parent for PhysicsParent {
 ///
 /// # Examples
 /// ```rust
-/// use specs_physics::bodies::util::SimplePosition;
+/// use specs_physics::SimplePosition;
 /// let dispatcher = specs_physics::physics_dispatcher::<f32, SimplePosition<f32>>();
 /// ```
 pub fn physics_dispatcher<'a, 'b, N, P>() -> Dispatcher<'a, 'b>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -236,13 +236,13 @@ extern crate log;
 
 pub use nalgebra;
 #[cfg(feature = "physics3d")]
-pub use ncollide3d as ncollide;
+extern crate ncollide3d as ncollide;
 #[cfg(feature = "physics3d")]
-pub use nphysics3d as nphysics;
+extern crate nphysics3d as nphysics;
 #[cfg(feature = "physics2d")]
-pub use ncollide2d as ncollide;
+extern crate ncollide2d as ncollide;
 #[cfg(feature = "physics2d")]
-pub use nphysics2d as nphysics;
+extern crate nphysics2d as nphysics;
 pub use shrev;
 
 use std::collections::HashMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,14 +113,14 @@
 //! ```rust
 //! use specs_physics::{
 //!     colliders::Shape,
-//!     nalgebra::{Isometry3, Vector3},
+//!     nalgebra::{Isometry3, Vector},
 //!     ncollide::world::CollisionGroups,
 //!     nphysics::material::{BasicMaterial, MaterialHandle},
 //!     PhysicsColliderBuilder,
 //! };
 //!
 //! let physics_collider = PhysicsColliderBuilder::from(
-//!         Shape::Cuboid{ half_extents: Vector3::new(10.0, 10.0, 1.0) })
+//!         Shape::Cuboid{ half_extents: Vector::new(10.0, 10.0, 1.0) })
 //!     .offset_from_parent(Isometry3::identity())
 //!     .density(1.2)
 //!     .material(MaterialHandle::new(BasicMaterial::default()))
@@ -240,8 +240,14 @@
 extern crate log;
 
 pub use nalgebra;
+#[cfg(feature = "physics3d")]
 pub use ncollide3d as ncollide;
+#[cfg(feature = "physics3d")]
 pub use nphysics3d as nphysics;
+#[cfg(feature = "physics2d")]
+pub use ncollide2d as ncollide;
+#[cfg(feature = "physics2d")]
+pub use nphysics2d as nphysics;
 pub use shrev;
 
 use std::collections::HashMap;
@@ -258,7 +264,7 @@ pub use self::{
 
 use self::{
     bodies::Position,
-    nalgebra::{RealField, Vector3},
+    nalgebra::RealField,
     nphysics::{
         counters::Counters,
         material::MaterialsCoefficientsTable,
@@ -271,6 +277,12 @@ use self::{
         SyncCollidersToPhysicsSystem, SyncParametersToPhysicsSystem,
     },
 };
+
+#[cfg(feature = "physics3d")]
+use nalgebra::Vector3 as Vector;
+
+#[cfg(feature = "physics2d")]
+use nalgebra::Vector2 as Vector;
 
 pub mod bodies;
 pub mod colliders;
@@ -308,7 +320,7 @@ impl<N: RealField> Physics<N> {
 
     /// Reports the internal value for the gravity.
     /// See also `Gravity` for setting this value.
-    pub fn gravity(&self) -> &Vector3<N> {
+    pub fn gravity(&self) -> &Vector<N> {
         self.world.gravity()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,7 @@
 //! Example for a `Position` `Component`, simply using the "Isometry" type (aka
 //! combined translation and rotation structure) directly:
 //!
-//! ```rust
+//! ```rust,ignore
 //! use specs::{Component, DenseVecStorage, FlaggedStorage};
 //! use specs_physics::{bodies::Position, nalgebra::Isometry3};
 //!
@@ -80,7 +80,7 @@
 //!
 //! Example:
 //!
-//! ```rust
+//! ```rust,ignore
 //! use specs_physics::{
 //!     nalgebra::{Matrix3, Point3},
 //!     nphysics::{algebra::Velocity3, object::BodyStatus},
@@ -105,17 +105,17 @@
 //!
 //! Example:
 //!
-//! ```rust
+//! ```rust,ignore
 //! use specs_physics::{
 //!     colliders::Shape,
-//!     nalgebra::{Isometry3, Vector},
+//!     nalgebra::{Isometry3, Vector3},
 //!     ncollide::world::CollisionGroups,
 //!     nphysics::material::{BasicMaterial, MaterialHandle},
 //!     PhysicsColliderBuilder,
 //! };
 //!
 //! let physics_collider = PhysicsColliderBuilder::from(
-//!         Shape::Cuboid{ half_extents: Vector::new(10.0, 10.0, 1.0) })
+//!         Shape::Cuboid{ half_extents: Vector3::new(10.0, 10.0, 1.0) })
 //!     .offset_from_parent(Isometry3::identity())
 //!     .density(1.2)
 //!     .material(MaterialHandle::new(BasicMaterial::default()))
@@ -160,7 +160,7 @@
 //!
 //! An example `Dispatcher` with all required `System`s:
 //!
-//! ```rust
+//! ```rust,no_run
 //! use specs::DispatcherBuilder;
 //! use specs_physics::{
 //!     systems::{
@@ -209,8 +209,8 @@
 //! If you're using [Amethyst] Transforms directly, you'd pass the generic
 //! arguments like so:
 //!
-//! ```rust,norun
-//! use amethyst_core::{Float, Transform};
+//! ```rust,ignore
+//! use amethyst::core::{Float, Transform};
 //! use specs_physics::systems::SyncBodiesToPhysicsSystem;
 //! SyncBodiesToPhysicsSystem::<Float, Transform>::default();
 //! ```
@@ -236,13 +236,13 @@ extern crate log;
 
 pub use nalgebra;
 #[cfg(feature = "physics3d")]
-extern crate ncollide3d as ncollide;
+pub extern crate ncollide3d as ncollide;
 #[cfg(feature = "physics3d")]
-extern crate nphysics3d as nphysics;
+pub extern crate nphysics3d as nphysics;
 #[cfg(feature = "physics2d")]
-extern crate ncollide2d as ncollide;
+pub extern crate ncollide2d as ncollide;
 #[cfg(feature = "physics2d")]
-extern crate nphysics2d as nphysics;
+pub extern crate nphysics2d as nphysics;
 pub use shrev;
 
 use std::collections::HashMap;
@@ -376,7 +376,7 @@ impl Parent for PhysicsParent {
 /// required physics related `System`s.
 ///
 /// # Examples
-/// ```
+/// ```rust
 /// use specs_physics::bodies::util::SimplePosition;
 /// let dispatcher = specs_physics::physics_dispatcher::<f32, SimplePosition<f32>>();
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,9 +8,9 @@
 //! specs-physics = "0.3.0"
 //! ```
 //!
-//! **specs-physics** defines a set of [Specs][] `System`s and `Component`s to
-//! handle the creation, modification and removal of [nphysics][] objects
-//! ([RigidBody][], [Collider][]) and the synchronisation of object positions
+//! **specs-physics** defines a set of [Specs] `System`s and `Component`s to
+//! handle the creation, modification and removal of [nphysics] objects
+//! ([RigidBody], [Collider]) and the synchronisation of object positions
 //! and global gravity between both worlds.
 //!
 //! ### Generic types
@@ -22,7 +22,7 @@
 //!
 //! #### `N: RealField`
 //!
-//! [nphysics][] is built upon [nalgebra][] and uses various types and
+//! [nphysics] is built upon [nalgebra] and uses various types and
 //! structures from this crate. **specs-physics** builds up on this even further
 //! and utilises the same structures, which all work with any type that
 //! implements `nalgebra::RealField`. `nalgebra::RealField` is by default
@@ -34,8 +34,8 @@
 //! a type parameter which implements the `specs_physics::bodies::Position`
 //! *trait*, requiring also a `Component` implementation with a
 //! `FlaggedStorage`. This `Position` `Component` is used to initially place a
-//! [RigidBody][] in the [nphysics][] world and later used to synchronise the
-//! updated translation and rotation of these bodies back into the [Specs][]
+//! [RigidBody] in the [nphysics] world and later used to synchronise the
+//! updated translation and rotation of these bodies back into the [Specs]
 //! world.
 //!
 //! Example for a `Position` `Component`, simply using the "Isometry" type (aka
@@ -67,7 +67,7 @@
 //! }
 //! ```
 //!
-//! If you're using [Amethyst][], you can enable the "amethyst" feature for this
+//! If you're using [Amethyst], you can enable the "amethyst" feature for this
 //! crate which provides a `Position<Float>` impl for `Transform`.
 //!
 //! ```toml
@@ -79,9 +79,9 @@
 //!
 //! ##### PhysicsBody
 //!
-//! The `specs_physics::PhysicsBody` `Component` is used to define [RigidBody][]
-//! from the comforts of your [Specs][] world. Changes to the `PhysicsBody` will
-//! automatically be synchronised with [nphysics][].
+//! The `specs_physics::PhysicsBody` `Component` is used to define [RigidBody]
+//! from the comforts of your [Specs] world. Changes to the `PhysicsBody` will
+//! automatically be synchronised with [nphysics].
 //!
 //! Example:
 //!
@@ -105,8 +105,8 @@
 //!
 //! `specs_physics::PhysicsCollider`s are the counterpart to `PhysicsBody`s.
 //! They can exist on their own or as a part of a `PhysicsBody`
-//! `PhysicsCollider`s are used to define and create [Collider][]'s in
-//! [nphysics][].
+//! `PhysicsCollider`s are used to define and create [Collider]'s in
+//! [nphysics].
 //!
 //! Example:
 //!
@@ -132,8 +132,8 @@
 //!     .build();
 //! ```
 //!
-//! To assign multiple [Collider][]'s the the same body, [Entity hierarchy][]
-//! can be used. This utilises [specs-hierarchy][].
+//! To assign multiple [Collider]'s the the same body, [Entity hierarchy]
+//! can be used. This utilises [specs-hierarchy].
 //!
 //! ### Systems
 //!
@@ -141,26 +141,26 @@
 //! `Dispatcher` in order:
 //!
 //! 1. `specs_physics::systems::SyncBodiesToPhysicsSystem` - handles the
-//! creation, modification and removal of [RigidBody][]'s based on the
+//! creation, modification and removal of [RigidBody]'s based on the
 //! `PhysicsBody` `Component` and an implementation of the `Position`
 //! *trait*.
 //!
 //! 2. `specs_physics::systems::SyncCollidersToPhysicsSystem` - handles
-//! the creation, modification and removal of [Collider][]'s based on the
+//! the creation, modification and removal of [Collider]'s based on the
 //! `PhysicsCollider` `Component`. This `System` depends on
-//! `SyncBodiesToPhysicsSystem` as [Collider][] can depend on [RigidBody][].
+//! `SyncBodiesToPhysicsSystem` as [Collider] can depend on [RigidBody].
 //!
 //! 3. `specs_physics::systems::SyncParametersToPhysicsSystem` - handles the
-//! modification of the [nphysics][] `World`s parameters.
+//! modification of the [nphysics] `World`s parameters.
 //!
 //! 4. `specs_physics::systems::PhysicsStepperSystem` - handles the progression
-//! of the [nphysics][] `World` and causes objects to actually move and
+//! of the [nphysics] `World` and causes objects to actually move and
 //! change their position. This `System` is the backbone for collision
 //! detection.
 //!
 //! 5. `specs_physics::systems::SyncBodiesFromPhysicsSystem` -
-//! handles the synchronisation of [RigidBody][] positions and dynamics back
-//! into the [Specs][] `Component`s. This `System` also utilises the
+//! handles the synchronisation of [RigidBody] positions and dynamics back
+//! into the [Specs] `Component`s. This `System` also utilises the
 //! `Position` *trait* implementation.
 //!
 //! An example `Dispatcher` with all required `System`s:
@@ -211,10 +211,10 @@
 //!     .build();
 //! ```
 //!
-//! If you're using [Amethyst][] Transforms directly, you'd pass the generic
+//! If you're using [Amethyst] Transforms directly, you'd pass the generic
 //! arguments like so:
 //!
-//! ```
+//! ```rust,norun
 //! use amethyst_core::{Float, Transform};
 //! use specs_physics::systems::SyncBodiesToPhysicsSystem;
 //! SyncBodiesToPhysicsSystem::<Float, Transform>::default();

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -5,9 +5,15 @@
 use std::ops::{Deref, DerefMut};
 
 use crate::{
-    nalgebra::{self as na, RealField, Scalar, Vector3},
+    nalgebra::{self as na, RealField, Scalar},
     nphysics::solver::IntegrationParameters,
 };
+
+#[cfg(feature = "physics3d")]
+use nalgebra::Vector3 as Vector;
+
+#[cfg(feature = "physics2d")]
+use nalgebra::Vector2 as Vector;
 
 /// The `TimeStep` is used to set the timestep of the nphysics integration, see
 /// `nphysics::world::World::set_timestep(..)`.
@@ -41,13 +47,13 @@ impl<N: RealField> Default for TimeStep<N> {
     }
 }
 
-/// `Gravity` is a newtype for `Vector3`. It represents a constant
+/// `Gravity` is a newtype for `Vector`. It represents a constant
 /// acceleration affecting all physical objects in the scene.
 #[derive(Debug, PartialEq)]
-pub struct Gravity<N: RealField + Scalar>(pub Vector3<N>);
+pub struct Gravity<N: RealField + Scalar>(pub Vector<N>);
 
 impl<N: RealField + Scalar> Deref for Gravity<N> {
-    type Target = Vector3<N>;
+    type Target = Vector<N>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -62,7 +68,7 @@ impl<N: RealField + Scalar> DerefMut for Gravity<N> {
 
 impl<N: RealField + Scalar> Default for Gravity<N> {
     fn default() -> Self {
-        Self(Vector3::<N>::zeros())
+        Self(Vector::<N>::zeros())
     }
 }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -4,10 +4,9 @@
 
 use std::ops::{Deref, DerefMut};
 
-use crate::{
-    nalgebra::{self as na, RealField, Scalar},
-    nphysics::solver::IntegrationParameters,
-};
+use nalgebra::{convert, RealField, Scalar};
+use nphysics::solver::IntegrationParameters;
+
 
 #[cfg(feature = "physics3d")]
 use nalgebra::Vector3 as Vector;
@@ -43,7 +42,7 @@ impl<N: RealField> DerefMut for TimeStep<N> {
 
 impl<N: RealField> Default for TimeStep<N> {
     fn default() -> Self {
-        Self(na::convert(1.0 / 60.0))
+        Self(convert(1.0 / 60.0))
     }
 }
 
@@ -195,14 +194,14 @@ impl<N: RealField> PartialEq<IntegrationParameters<N>> for PhysicsIntegrationPar
 impl<N: RealField> Default for PhysicsIntegrationParameters<N> {
     fn default() -> Self {
         PhysicsIntegrationParameters {
-            error_reduction_parameter: na::convert(0.2),
-            warmstart_coefficient: na::convert(1.0),
-            restitution_velocity_threshold: na::convert(1.0),
-            allowed_linear_error: na::convert(0.001),
-            allowed_angular_error: na::convert(0.001),
-            max_linear_correction: na::convert(100.0),
-            max_angular_correction: na::convert(0.2),
-            max_stabilization_multiplier: na::convert(0.2),
+            error_reduction_parameter: convert(0.2),
+            warmstart_coefficient: convert(1.0),
+            restitution_velocity_threshold: convert(1.0),
+            allowed_linear_error: convert(0.001),
+            allowed_angular_error: convert(0.001),
+            max_linear_correction: convert(100.0),
+            max_angular_correction: convert(0.2),
+            max_stabilization_multiplier: convert(0.2),
             max_velocity_iterations: 8,
             max_position_iterations: 3,
         }

--- a/src/positon.rs
+++ b/src/positon.rs
@@ -1,0 +1,80 @@
+use specs::{Component, DenseVecStorage, FlaggedStorage};
+use std::ops::{Deref, DerefMut};
+use nalgebra::RealField;
+
+#[cfg(feature = "physics3d")]
+use nalgebra::{Point3 as Point, Isometry3 as Isometry};
+
+#[cfg(feature = "physics2d")]
+use nalgebra::{Point2 as Point, Isometry2 as Isometry};
+
+
+/// An implementation of the `Position` trait is required for the
+/// synchronisation of the position of Specs and nphysics objects.
+///
+/// Initially, it is used to position bodies in the nphysics `World`. Then after
+/// progressing the `World` it is used to synchronise the updated positions back
+/// towards Specs.
+pub trait Position<N: RealField>:
+Component<Storage = FlaggedStorage<Self, DenseVecStorage<Self>>> + Send + Sync
+{
+    fn isometry(&self) -> &Isometry<N>;
+    fn isometry_mut(&mut self) -> &mut Isometry<N>;
+
+    /// Helper function to extract the location of this `Position`. Using `Position::isometry()` is
+    /// preferable, but can be harder to work with. The translation of this `Position` can be set
+    /// using `Position::isometry_mut()`.
+    fn translation(&self) -> Point<N> {
+        self.isometry().translation.vector.into()
+    }
+
+    /// Helper function to extract the rotation of this `Position`. Using `Position::isometry()` is
+    /// preferable, but can be harder to work with. The rotation of this `Position` can be set
+    /// using `Position::isometry_mut()`. This is only available when the `physics2d` feature is
+    /// enabled.
+    #[cfg(feature = "physics2d")]
+    fn angle(&self) -> N {
+        self.isometry().rotation.angle()
+    }
+}
+
+#[cfg(feature = "amethyst")]
+impl Position<f32> for amethyst_core::Transform {
+    fn isometry(&self) -> &Isometry<f32> {
+        self.isometry()
+    }
+
+    fn isometry_mut(&mut self) -> &mut Isometry<f32> {
+        self.isometry_mut()
+    }
+}
+
+pub struct SimplePosition<N: RealField>(pub Isometry<N>);
+
+impl<N: RealField> Position<N> for SimplePosition<N> {
+    fn isometry(&self) -> &Isometry<N> {
+        &self.0
+    }
+
+    fn isometry_mut(&mut self) -> &mut Isometry<N> {
+        &mut self.0
+    }
+}
+
+impl<N: RealField> Component for SimplePosition<N> {
+    type Storage = FlaggedStorage<Self, DenseVecStorage<Self>>;
+}
+
+impl<N: RealField> Deref for SimplePosition<N> {
+    type Target = Isometry<N>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<N: RealField> DerefMut for SimplePosition<N> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/src/systems/physics_stepper.rs
+++ b/src/systems/physics_stepper.rs
@@ -4,14 +4,12 @@ use specs::{
     world::Index, Entities, Entity, Read, Resources, System, SystemData, Write, WriteExpect,
 };
 
-use crate::{
-    events::{ContactEvent, ContactEvents, ContactType, ProximityEvent, ProximityEvents},
-    nalgebra::RealField,
-    ncollide::{events::ContactEvent as NContactEvent, world::CollisionObjectHandle},
-    nphysics::world::ColliderWorld,
-    parameters::TimeStep,
-    Physics,
-};
+use crate::events::{ContactEvent, ContactEvents, ContactType, ProximityEvent, ProximityEvents};
+use nalgebra::RealField;
+use ncollide::{events::ContactEvent as NContactEvent, world::CollisionObjectHandle};
+use nphysics::world::ColliderWorld;
+use crate::parameters::TimeStep;
+use crate::Physics;
 
 /// The `PhysicsStepperSystem` progresses the nphysics `World`.
 pub struct PhysicsStepperSystem<N> {

--- a/src/systems/sync_bodies_from_physics.rs
+++ b/src/systems/sync_bodies_from_physics.rs
@@ -2,7 +2,8 @@ use std::marker::PhantomData;
 
 use specs::{Join, ReadExpect, Resources, System, SystemData, WriteStorage};
 
-use crate::bodies::{PhysicsBody, Position};
+use crate::bodies::PhysicsBody;
+use crate::positon::Position;
 use crate::Physics;
 use nalgebra::RealField;
 

--- a/src/systems/sync_bodies_from_physics.rs
+++ b/src/systems/sync_bodies_from_physics.rs
@@ -2,11 +2,9 @@ use std::marker::PhantomData;
 
 use specs::{Join, ReadExpect, Resources, System, SystemData, WriteStorage};
 
-use crate::{
-    bodies::{PhysicsBody, Position},
-    nalgebra::RealField,
-    Physics,
-};
+use crate::bodies::{PhysicsBody, Position};
+use crate::Physics;
+use nalgebra::RealField;
 
 /// The `SyncBodiesFromPhysicsSystem` synchronised the updated position of
 /// the `RigidBody`s in the nphysics `World` with their Specs counterparts. This

--- a/src/systems/sync_bodies_from_physics.rs
+++ b/src/systems/sync_bodies_from_physics.rs
@@ -35,7 +35,7 @@ where
             // if a RigidBody exists in the nphysics World we fetch it and update the
             // Position component accordingly
             if let Some(rigid_body) = physics.world.rigid_body(physics_body.handle.unwrap()) {
-                position.set_isometry(rigid_body.position());
+                *position.isometry_mut() = *rigid_body.position();
                 physics_body.update_from_physics_world(rigid_body);
             }
         }

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -6,7 +6,8 @@ use specs::{
 };
 
 use nalgebra::RealField;
-use crate::bodies::{PhysicsBody, Position};
+use crate::bodies::PhysicsBody;
+use crate::positon::Position;
 use crate::Physics;
 
 use super::iterate_component_events;

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -195,7 +195,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "physics3d"))]
 mod tests {
     use nalgebra::Isometry3;
     use nphysics::object::BodyStatus;

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -5,11 +5,9 @@ use specs::{
     SystemData, WriteExpect, WriteStorage,
 };
 
-use crate::{
-    bodies::{PhysicsBody, Position},
-    nalgebra::RealField,
-    Physics,
-};
+use nalgebra::RealField;
+use crate::bodies::{PhysicsBody, Position};
+use crate::Physics;
 
 use super::iterate_component_events;
 
@@ -199,10 +197,9 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        nalgebra::Isometry3, nphysics::object::BodyStatus, systems::SyncBodiesToPhysicsSystem,
-        Physics, PhysicsBodyBuilder, SimplePosition,
-    };
+    use nalgebra::Isometry3;
+    use nphysics::object::BodyStatus;
+    use crate::{systems::SyncBodiesToPhysicsSystem, Physics, PhysicsBodyBuilder, SimplePosition};
 
     use specs::{world::Builder, DispatcherBuilder, World};
 

--- a/src/systems/sync_colliders_to_physics.rs
+++ b/src/systems/sync_colliders_to_physics.rs
@@ -5,13 +5,11 @@ use specs::{
     SystemData, WriteExpect, WriteStorage,
 };
 
-use crate::{
-    bodies::Position,
-    colliders::PhysicsCollider,
-    nalgebra::RealField,
-    nphysics::object::{BodyPartHandle, ColliderDesc},
-    Physics, PhysicsParent,
-};
+use crate::bodies::Position;
+use crate::colliders::PhysicsCollider;
+use crate::{Physics, PhysicsParent};
+use nalgebra::RealField;
+use nphysics::object::{BodyPartHandle, ColliderDesc};
 
 use super::iterate_component_events;
 
@@ -254,8 +252,9 @@ where
 mod tests {
     use specs::{world::Builder, DispatcherBuilder, World};
 
+    use nalgebra::Isometry3;
     use crate::{
-        colliders::Shape, nalgebra::Isometry3, systems::SyncCollidersToPhysicsSystem, Physics,
+        colliders::Shape, systems::SyncCollidersToPhysicsSystem, Physics,
         PhysicsColliderBuilder, SimplePosition,
     };
 

--- a/src/systems/sync_colliders_to_physics.rs
+++ b/src/systems/sync_colliders_to_physics.rs
@@ -5,7 +5,7 @@ use specs::{
     SystemData, WriteExpect, WriteStorage,
 };
 
-use crate::bodies::Position;
+use crate::positon::Position;
 use crate::colliders::PhysicsCollider;
 use crate::{Physics, PhysicsParent};
 use nalgebra::RealField;

--- a/src/systems/sync_colliders_to_physics.rs
+++ b/src/systems/sync_colliders_to_physics.rs
@@ -248,7 +248,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "physics3d"))]
 mod tests {
     use specs::{world::Builder, DispatcherBuilder, World};
 

--- a/src/systems/sync_parameters_to_physics.rs
+++ b/src/systems/sync_parameters_to_physics.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "physics3d"))]
 mod tests {
     use specs::{DispatcherBuilder, World};
 

--- a/src/systems/sync_parameters_to_physics.rs
+++ b/src/systems/sync_parameters_to_physics.rs
@@ -2,8 +2,8 @@ use std::marker::PhantomData;
 
 use specs::{Read, Resources, System, SystemData, WriteExpect};
 
+use nalgebra::RealField;
 use crate::{
-    nalgebra::RealField,
     parameters::{Gravity, PhysicsIntegrationParameters, PhysicsProfilingEnabled},
     Physics,
 };
@@ -81,9 +81,8 @@ where
 mod tests {
     use specs::{DispatcherBuilder, World};
 
-    use crate::{
-        nalgebra::Vector3, parameters::Gravity, systems::SyncParametersToPhysicsSystem, Physics,
-    };
+    use nalgebra::Vector3;
+    use crate::{parameters::Gravity, systems::SyncParametersToPhysicsSystem, Physics};
 
     #[test]
     fn update_gravity() {


### PR DESCRIPTION
The main part of this pull request is adding support for 2d physics through the use of features. I also made some other changes when I was not intending to make a pull request that I listed below.

## changes
 - You must use either the `physics2d` or `physics3d` feature. I really wanted to make it so that `physics3d` was the default unless `physics2d` was enabled, but I was unable to find a good way to do that without requiring both as dependencies at the same time and using `#[cfg(feature = "physics2d")]` and `#[cfg(not(feature = "physics2d"))]`.
 - Changed the way imports were handled throughout the project. In `lib.rs` there physics crates were re-exported `pub use nphysics3d as nphysics`. However all of the other modules then referenced `nphysics3d` using `use crate::nphysics::{ /* etc. */}`. I changed it to the format:
   - ```rust
     // Extern used to rename the import globally
     #[cfg(feature = "physics3d")]
     pub extern crate nphysics3d as nphysics;
     #[cfg(feature = "physics2d")]
     pub extern crate nphysics2d as nphysics;
     ```
   - `use nphysics::{ /* etc. */ };`
 - Minor typos in docs where links were written as `[link_name][]` instead of the more correct `[link_name]`.
 - Remove the repetitive `set_isometry` function in `Position` in favor of using the already present `isometry_mut` function.
   - Previous usage: `position.set_isometry(rigid_body.position());`
   - New usage: `*position.isometry_mut() = *rigid_body.position();`
 - Downgrade some of the dependencies (like shrev) to make sure that they lined up with the current release of amethyst. When I first tried using `specs-physics` cargo built an extra ~10-15 packages (almost all duplicates).
 - Extract `Position` and `SimplePosition` to a separate module.