### PR TITLE
Fix clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ objekt = "0.1.2"
 
 [dev-dependencies]
 simple_logger = "1.2.0"
+approx = "0.3.2"
 
 [[example]]
 name = "basic"

--- a/src/colliders.rs
+++ b/src/colliders.rs
@@ -107,10 +107,7 @@ impl<N: RealField> Shape<N> {
                 radius,
             } => ShapeHandle::new(Capsule::new(*half_height, *radius)),
             Shape::Compound { parts } => ShapeHandle::new(Compound::new(
-                parts
-                    .into_iter()
-                    .map(|part| (part.0, part.1.handle()))
-                    .collect(),
+                parts.iter().map(|part| (part.0, part.1.handle())).collect(),
             )),
             Shape::ConvexHull { points } => ShapeHandle::new(
                 ConvexHull::try_from_points(&points)

--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -239,7 +239,7 @@ mod tests {
             )))
             .with(PhysicsBodyBuilder::<f32>::from(BodyStatus::Dynamic).build())
             .build();
-        dispatcher.dispatch(&mut world);
+        dispatcher.dispatch(&world);
 
         // fetch the Physics instance and check for new bodies
         let physics = world.read_resource::<Physics<f32>>();

--- a/src/systems/sync_colliders_to_physics.rs
+++ b/src/systems/sync_colliders_to_physics.rs
@@ -292,7 +292,7 @@ mod tests {
             )))
             .with(PhysicsColliderBuilder::<f32>::from(Shape::Ball { radius: 5.0 }).build())
             .build();
-        dispatcher.dispatch(&mut world);
+        dispatcher.dispatch(&world);
 
         // fetch the Physics instance and check for new colliders
         let physics = world.read_resource::<Physics<f32>>();

--- a/src/systems/sync_parameters_to_physics.rs
+++ b/src/systems/sync_parameters_to_physics.rs
@@ -79,6 +79,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use approx::assert_ulps_eq;
     use specs::prelude::*;
 
     use crate::{
@@ -104,8 +105,8 @@ mod tests {
         dispatcher.dispatch(&world);
 
         let physics = world.read_resource::<Physics<f32>>();
-        assert_eq!(physics.world.gravity().x, 1.0);
-        assert_eq!(physics.world.gravity().y, 2.0);
-        assert_eq!(physics.world.gravity().z, 3.0);
+        assert_ulps_eq!(physics.world.gravity().x, 1.0);
+        assert_ulps_eq!(physics.world.gravity().y, 2.0);
+        assert_ulps_eq!(physics.world.gravity().z, 3.0);
     }
 }

--- a/src/systems/sync_parameters_to_physics.rs
+++ b/src/systems/sync_parameters_to_physics.rs
@@ -100,13 +100,12 @@ mod tests {
             .build();
         dispatcher.setup(&mut world);
 
-        world.insert(Gravity(Vector3::<f32>::new(1.0, 2.0, 3.0).into()));
-        dispatcher.dispatch(&mut world);
+        world.insert(Gravity(Vector3::<f32>::new(1.0, 2.0, 3.0)));
+        dispatcher.dispatch(&world);
 
         let physics = world.read_resource::<Physics<f32>>();
         assert_eq!(physics.world.gravity().x, 1.0);
         assert_eq!(physics.world.gravity().y, 2.0);
         assert_eq!(physics.world.gravity().z, 3.0);
     }
-
 }


### PR DESCRIPTION
~~I didn't fix [the float comparison warnings](https://github.com/amethyst/specs-physics/blob/021e649d07fb37092e211f3acb58932ef5517bdc/src/systems/sync_parameters_to_physics.rs#L107), but I got everything else.~~ I fixed all the warnings.