### PR TITLE
Avoid overlapping collide example bodies

### DIFF
--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -38,8 +38,9 @@ fn main() {
         )
         .with(
             PhysicsColliderBuilder::<f32>::from(Shape::Cuboid {
-                half_extents: Vector3::new(2.0, 2.0, 1.0),
+                half_extents: Vector3::new(1.9, 2.0, 1.0),
             })
+            .margin(0.1)
             .build(),
         )
         .build();
@@ -49,13 +50,14 @@ fn main() {
     world
         .create_entity()
         .with(SimplePosition::<f32>(Isometry3::<f32>::translation(
-            3.0, 1.0, 1.0,
+            5.0, 1.0, 1.0,
         )))
         .with(PhysicsBodyBuilder::<f32>::from(BodyStatus::Static).build())
         .with(
             PhysicsColliderBuilder::<f32>::from(Shape::Cuboid {
-                half_extents: Vector3::new(2.0, 2.0, 1.0),
+                half_extents: Vector3::new(1.9, 2.0, 1.0),
             })
+            .margin(0.1)
             .build(),
         )
         .build();


### PR DESCRIPTION
The two collision regions in the Collide demo overlap

To 1.0 on X (-1.0 .. 3.0) and 5.0 (3.0 .. 5.0)

(Before, running this example caused the rigidbody to shoot off into the distance)