### PR TITLE
Fix example features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,25 +43,25 @@ approx = "0.3"
 [[example]]
 name = "basic"
 path = "examples/basic.rs"
-required-features = ["physics3d"]
+required-features = ["dim3"]
 
 [[example]]
 name = "hierarchy"
 path = "examples/hierarchy.rs"
-required-features = ["physics3d"]
+required-features = ["dim3"]
 
 [[example]]
 name = "positions"
 path = "examples/positions.rs"
-required-features = ["physics3d"]
+required-features = ["dim3"]
 
 [[example]]
 name = "collision"
 path = "examples/collision.rs"
-required-features = ["physics3d"]
+required-features = ["dim3"]
 
 [[example]]
 name = "events"
 path = "examples/events.rs"
-required-features = ["physics3d"]
+required-features = ["dim3"]
 

--- a/examples/collision.rs
+++ b/examples/collision.rs
@@ -46,7 +46,7 @@ fn main() {
     world
         .create_entity()
         .with(SimplePosition::<f32>(Isometry3::<f32>::translation(
-            3.0, 1.0, 1.0,
+            5.0, 1.0, 1.0,
         )))
         .with(PhysicsBodyBuilder::<f32>::from(BodyStatus::Static).build())
         .with(


### PR DESCRIPTION
I had this conversation with Cargo which highlighted that the examples features didn't make sense. I believe I've made a correction for now..

```
C:\gamedev\learning\specs-physics>cargo run --example collision
error: target `collision` in package `specs-physics` requires the features: `physics3d`
Consider enabling them by passing, e.g., `--features="physics3d"`

C:\gamedev\learning\specs-physics>cargo run --example collision --features="physics3d"
error: Package `specs-physics v0.4.0 (C:\gamedev\learning\specs-physics)` does not have these features: `physics3d`

```

Note however that I cannot compile your 0.4.0 branch using stable-i686-pc-windows-gnu or nightly.

```
C:\gamedev\learning\specs-physics>cargo run --example collision --features="dim3"
...

error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'a` due to conflicting requirements
  --> src\systems\physics_stepper.rs:18:24
   |
18 | impl<'a, N: RealField> System<'a> for PhysicsStepperSystem<N> {
   |                        ^^^^^^^^^^
   |
note: first, the lifetime cannot outlive the lifetime 'a as defined on the impl at 18:6...
  --> src\systems\physics_stepper.rs:18:6
   |
18 | impl<'a, N: RealField> System<'a> for PhysicsStepperSystem<N> {
   |      ^^
   = note: ...so that the types are compatible:
           expected shred::system::System<'a>
              found shred::system::System<'_>
   = note: but, the lifetime must be valid for the static lifetime...
note: ...so that the type `nphysics3d::world::mechanical_world::MechanicalWorld<N, world::BodySet<'_, N>, specs::world::entity::Entity>` will meet its required lifetime bounds
  --> src\systems\physics_stepper.rs:18:24
   |
18 | impl<'a, N: RealField> System<'a> for PhysicsStepperSystem<N> {
   |                        ^^^^^^^^^^

error: aborting due to previous error

error: Could not compile `specs-physics`.
```