### PR TITLE
Make `cargo test` pass w/o `amethyst` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,9 +215,13 @@
 //! arguments like so:
 //!
 //! ```
-//! use amethyst_core::Transform;
-//! use specs_physics::systems::SyncBodiesToPhysicsSystem;
-//! SyncBodiesToPhysicsSystem::<f32, Transform>::default();
+//! // This code will only compile if the amethyst feature is enabled
+//! #[cfg(amethyst)]
+//! {
+//!     use amethyst_core::Transform;
+//!     use specs_physics::systems::SyncBodiesToPhysicsSystem;
+//!     SyncBodiesToPhysicsSystem::<f32, Transform>::default();
+//! }
 //! ```
 //!
 //! Alternatively to building your own `Dispatcher`, you can always fall back on


### PR DESCRIPTION
I did this by gating the test code behind a feature flag