### PR TITLE
Fix: removed entities were not synced to the engine

### DIFF
--- a/src/systems/sync_bodies_to_physics.rs
+++ b/src/systems/sync_bodies_to_physics.rs
@@ -57,6 +57,11 @@ where
                 self.physics_bodies_reader_id.as_mut().unwrap(),
             );
 
+        // handle removed events
+        for id in &removed_physics_bodies | &removed_positions {
+            remove_rigid_body::<N, P>(id, &mut physics);
+        }
+
         // iterate over PhysicsBody and Position components with an id/Index that
         // exists in either of the collected ComponentEvent BitSets
         for (position, mut physics_body, id) in (
@@ -88,12 +93,6 @@ where
                     &modified_positions,
                     &modified_physics_bodies,
                 );
-            }
-
-            // handle removed events
-            if removed_positions.contains(id) || removed_physics_bodies.contains(id) {
-                debug!("Removed PhysicsBody with id: {}", id);
-                remove_rigid_body::<N, P>(id, &mut physics);
             }
         }
     }

--- a/src/systems/sync_colliders_to_physics.rs
+++ b/src/systems/sync_colliders_to_physics.rs
@@ -59,6 +59,11 @@ where
                 &physics_colliders,
                 self.physics_colliders_reader_id.as_mut().unwrap(),
             );
+        
+        // handle removed events
+        for id in &removed_physics_colliders {
+            remove_collider::<N, P>(id, &mut physics);
+        }
 
         // iterate over PhysicsCollider and Position components with an id/Index that
         // exists in either of the collected ComponentEvent BitSets
@@ -89,12 +94,6 @@ where
             if modified_physics_colliders.contains(id) {
                 debug!("Modified PhysicsCollider with id: {}", id);
                 update_collider::<N, P>(id, &mut physics, physics_collider.get_unchecked());
-            }
-
-            // handle removed events
-            if removed_physics_colliders.contains(id) {
-                debug!("Removed PhysicsCollider with id: {}", id);
-                remove_collider::<N, P>(id, &mut physics);
             }
         }
 


### PR DESCRIPTION
Hi.  I'm not 100% sure if I'm right because I'm didn't really know the Amethyst internals and the timing of the FlaggedStorage events but I had some issues when it comes to sync deleted entities back to the engine.  I saw they were never deleted.  Only if I insert an entity again, which got the id of a previously deleted entity, specs-physics detected it and deleted it.

I debugged a little bit and saw that it the join loop, where the sync calls are placed, the id of the deleted entities never appeared.  This makes sense since they are already deleted.  What I did is simply remove all the 'remove-ID's' outside of the loop.

Not sure if this can have any other side effects but it works perfectly on my end with this fix.